### PR TITLE
AL - Remove /api path causing issues with myRole endpoint

### DIFF
--- a/secrets-heroku.properties.SAMPLE
+++ b/secrets-heroku.properties.SAMPLE
@@ -4,12 +4,10 @@ app.member.hosted-domain=ucsb.edu
 app.ucsb.api.consumer_key=FILL-IT-IN
 spring.data.mongodb.uri=FILL-IT-IN
 
-
-
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN
 
-security.oauth2.resource.id=${app.namespace}/api
+security.oauth2.resource.id=${app.namespace}
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/secrets-localhost.properties.SAMPLE
+++ b/secrets-localhost.properties.SAMPLE
@@ -7,6 +7,5 @@ auth0.clientId=FILL-IN-AUTH0-CLIENT-ID
 app.ucsb.api.consumer_key=FILL-IT-IN
 spring.data.mongodb.uri=FILL-IT-IN
 
-
 security.oauth2.resource.id=https://YOUR-HEROKU-APP.herokuapp.com
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json


### PR DESCRIPTION
This PR addresses the issue of the `/api/myRole` endpoint not working when accessing a Heroku deployment of this app.

I don't remember why this fixes the issue, but I remember that we had to make this fix multiple times last quarter. Now that this change is in the sample file, we should hopefully not have this issue going forward.