### PR TITLE
qh,aa - Left align name and description fields

### DIFF
--- a/javascript/src/main/components/Schedule/ScheduleTable.js
+++ b/javascript/src/main/components/Schedule/ScheduleTable.js
@@ -29,11 +29,15 @@ const ScheduleTable = ({ data, deleteSchedule }) => {
     text: 'id'
   }, {
     dataField: 'name',
-    text: 'Name'
+    text: 'Name',
+    align: "left",
+    headerAlign: "left"
   },
   {
     dataField: 'description',
-    text: 'Description'
+    text: 'Description',
+    align: "left",
+    headerAlign: "left"
   },
   {
     dataField: 'quarter',


### PR DESCRIPTION
Resolves #106 

In this PR, we left aligned the name and description fields in the "schedule" page. 

