### PR TITLE
5pm 3 add instructor last name

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/CourseSearchFormInstructor.js
+++ b/javascript/src/main/components/BasicCourseSearch/CourseSearchFormInstructor.js
@@ -54,8 +54,9 @@ const CourseSearchFormInstructor = ({ setCourseJSON, fetchJSON }) => {
             </Form.Group>
             <Form.Group controlId="InstructorSearch.Instructor">
                 <Form.Label>Instructor</Form.Label>
-                <Form.Control type="text" onChange={handleInstructorOnChange} value={instructorText}>   
+                <Form.Control type="text" onChange={handleInstructorOnChange} value={instructorText} placeholder="Instructor Last Name">
                 </Form.Control>
+                <Form.Text style={{ textAlign: "left"}} muted>If there are multiple instructors with the same last name, do a search by last name first to determine how the instructor first name is abbreviated, e.g. WANG R K, WANG Y X, WANG Y F, etc. and then repeat the search.</Form.Text>
             </Form.Group>
             <Button variant="primary" type="submit">
                 Submit

--- a/javascript/src/test/components/BasicCourseSearch/CourseSearchFormInstructor.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/CourseSearchFormInstructor.test.js
@@ -80,5 +80,11 @@ test("when I click submit, I get back the information about a specified instruct
 
 });
 
+test("Instructor placeholder text correctly renders", async () => {
+    const { findByText } = render(<CourseSearchFormInstructor />);
+
+    await findByText("If there are multiple instructors with the same last name, do a search by last name first to determine how the instructor first name is abbreviated, e.g. WANG R K, WANG Y X, WANG Y F, etc. and then repeat the search.");
+  });
+
 });
 


### PR DESCRIPTION
This pull request closes issue #115 by adding a hint in the instructor field on the "Search by Instructor" page telling the user to enter the instructor's last name only as well as adding more of a description of the instructor field immediately beneath it.

The following image displays the changes on that page.
![image](https://user-images.githubusercontent.com/56096660/108145675-ae759b80-7080-11eb-8f20-9fd23cccdeee.png)
