### PR TITLE
5pm-4: Remove "From MongoDB" from the title of basic search and Add Data Description

### DIFF
--- a/javascript/src/main/pages/History/Basic.js
+++ b/javascript/src/main/pages/History/Basic.js
@@ -23,7 +23,7 @@ const Basic = () => {
     return (
         <Jumbotron>
             <div className="text-left">
-                <h5>Search Archived Course Data from MongoDB</h5>
+                <h5>Search Archived Course Data</h5>
                 <CourseSearchFormQtrDeptOnly setCourseJSON={setCourseJSON} fetchJSON={fetchBasicCourseHistoryJSON} />
                 <JSONPrettyCard
                     expression={"courseJSON"}

--- a/javascript/src/main/pages/History/Basic.js
+++ b/javascript/src/main/pages/History/Basic.js
@@ -24,6 +24,9 @@ const Basic = () => {
         <Jumbotron>
             <div className="text-left">
                 <h5>Search Archived Course Data</h5>
+                <p>Data on this page is accurate for past quarters, but may be 
+                    incomplete or out of date for current and future quarters.
+                    Course information is not immediately updated.</p>
                 <CourseSearchFormQtrDeptOnly setCourseJSON={setCourseJSON} fetchJSON={fetchBasicCourseHistoryJSON} />
                 <JSONPrettyCard
                     expression={"courseJSON"}

--- a/javascript/src/test/pages/History/Basic.test.js
+++ b/javascript/src/test/pages/History/Basic.test.js
@@ -4,6 +4,8 @@ import Basic from "main/pages/History/Basic";
 
 describe("History Basic Course Search page tests", () => {
   test("renders without crashing", () => {
-    render(<Basic/>);
+    const { getByText } =  render(<Basic/>);
+    expect(getByText("Data on this page is accurate for past quarters, but may be incomplete or out of date for current and future quarters. Course information is not immediately updated.")).toBeInTheDocument();
+    expect(getByText("Search Archived Course Data")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Removed "From MongoDB" from the title of basic search and added description of course data - "Data on this page is accurate for past quarters, but may be incomplete or out of date for current and future quarters. Course information is not immediately updated."

Closes #116
