### PR TITLE
AL - Add S21 quarter to basic search

### DIFF
--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -2,8 +2,7 @@ import React, { useState } from "react";
 import { Form, Button} from "react-bootstrap";
 
 const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
-
-    const [quarter, setQuarter] = useState("20211");
+    const [quarter, setQuarter] = useState("20212");
     const [department, setDepartment] = useState("CMPSC");
     const [level, setLevel] = useState("U");
     
@@ -31,6 +30,7 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
             <Form.Group controlId="BasicSearch.Quarter">
                 <Form.Label>Quarter</Form.Label>
                 <Form.Control as="select" onChange={handleQuarterOnChange} value={quarter} data-testid="select-quarter" >
+                    <option value="20212">S21</option>
                     <option value="20211">W21</option>
                     <option value="20204">F20</option>
                 </Form.Control>


### PR DESCRIPTION
It's time to register for Spring classes! This short PR adds the S21 option for the Basic Course Search on the main page and sets it as the default option.

This change is only being made in `BasicCourseSearchForm` for now, since the MongoDB archive doesn't have anything for S21 yet. I'll make a separate PR for the dropdowns of the archived course searches, which we can merge in when the MongoDB archive is made.