### PR TITLE
AL - Set Actions fetch depth to 2 to fix Codecov reports

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -16,6 +16,8 @@ jobs:
       NODE_PATH: src/
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Currently, there is an issue where Codecov status checks are occasionally not being reported. Upon reaching out to a Codecov support engineer, we believe the problem is GitHub Actions not being able to locate the previous commit SHA because `actions/checkout@v2` is [set by default to only fetch one commit](https://github.com/actions/checkout#whats-new). This PR fixes this problem by setting the `fetch-depth` to 2 instead of 1.

You can see the error in [this Actions run](https://github.com/ucsb-cs156-w21/proj-mapache-search/runs/1921966301), for example.

This change seemed to fix the problem in [proj-mapache-search](https://github.com/ucsb-cs156-w21/proj-mapache-search/pull/122), hopefully it works here as well.