### PR TITLE
Staff w21 add subjects api endpoint

### DIFF
--- a/src/main/java/edu/ucsb/courses/controllers/SubjectAreasController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/SubjectAreasController.java
@@ -1,0 +1,33 @@
+package edu.ucsb.courses.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import edu.ucsb.courses.services.UCSBCurriculumService;
+
+@RestController
+@RequestMapping("/api/public/subjects")
+public class SubjectAreasController {
+    private final Logger logger = LoggerFactory.getLogger(SubjectAreasController.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @GetMapping(value = "", produces = "application/json")
+    public ResponseEntity<String> getSubjects() throws JsonProcessingException {
+
+        String body = ucsbCurriculumService.getSubjectsJSON();
+        
+        return ResponseEntity.ok().body(body);
+    }  
+}

--- a/src/main/java/edu/ucsb/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/courses/services/UCSBCurriculumService.java
@@ -68,5 +68,32 @@ public class UCSBCurriculumService  {
         return retVal;
     }
 
+    public String getSubjectsJSON() {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "1.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String url = "https://api.ucsb.edu/students/lookups/v1/subjects";
+        logger.info("url=" + url);
+
+        String retVal = "";
+        MediaType contentType=null;
+        HttpStatus statusCode=null;
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            contentType = re.getHeaders().getContentType();
+            statusCode = re.getStatusCode();
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+        logger.info("json: {} contentType: {} statusCode: {}",retVal,contentType,statusCode);
+        return retVal;
+    }
     
 }

--- a/src/test/java/edu/ucsb/courses/controllers/SubjectAreasControllerTests.java
+++ b/src/test/java/edu/ucsb/courses/controllers/SubjectAreasControllerTests.java
@@ -1,0 +1,56 @@
+package edu.ucsb.courses.controllers;
+
+import edu.ucsb.courses.config.SecurityConfig;
+import edu.ucsb.courses.services.UCSBCurriculumService;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// @Import(SecurityConfig.class) applies the security rules 
+// so that /api/public/** endpoints don't require authentication.
+// Otherwise you may get authorization errors when running the test
+
+@WebMvcTest(value = SubjectAreasController.class)
+@Import(SecurityConfig.class)
+public class SubjectAreasControllerTests {
+
+    private final Logger logger = LoggerFactory.getLogger(SubjectAreasControllerTests.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @Test
+    public void test_getSubjects() throws Exception {
+
+        String expectedResult = "[  ]";
+        String url = "/api/public/subjects";
+        when(ucsbCurriculumService.getSubjectsJSON()).thenReturn(expectedResult);
+
+        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
+                .andReturn();
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
@@ -63,4 +63,23 @@ public class UCSBCurriculumServiceTest {
         assertEquals(expectedResult, result);
     }
 
+
+    @Test
+    public void test_getSubjectsJSON_success() throws Exception {
+        String expectedResult = "[ {deptCode: \"ANTH\"} ]";
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
+        String result = ucs.getSubjectsJSON();
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getSubjectsJSON_exception() throws Exception {
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(HttpClientErrorException.class);
+        String result = ucs.getSubjectsJSON();
+        assertEquals(expectedResult, result);
+    }
+
 }


### PR DESCRIPTION
In this PR, we add a new public api endpoint, `/api/public/subjects`.

This is a step towards being able  to populate drop down menus in the React front end with the subject areas that are active, rather than hard coding these.

This endpoint is a pass-through for the UCSB Developer API endpoint under Students, Student Record Code Lookups.

The JSON that comes back has this format: 

```
[
  {
    "subjectCode": "ANTH",
    "subjectTranslation": "Anthropology",
    "deptCode": "ANTH",
    "collegeCode": "L&S",
    "relatedDeptCode": null,
    "inactive": false
  },
  {
    "subjectCode": "ART  CS",
    "subjectTranslation": "Art (Creative Studies)",
    "deptCode": "CRSTU",
    "collegeCode": "CRST",
    "relatedDeptCode": null,
    "inactive": false
  },
  {
    "subjectCode": "ARTHI",
    "subjectTranslation": "Art History",
    "deptCode": "ARTHI",
    "collegeCode": "L&S",
    "relatedDeptCode": null,
    "inactive": false
  },
...
  {
    "subjectCode": "ARTHIW",
    "subjectTranslation": "Art History (Online)",
    "deptCode": "ARTHI",
    "collegeCode": "L&S",
    "relatedDeptCode": null,
    "inactive": false
  },
  {
    "subjectCode": "FAMSTW",
    "subjectTranslation": "Film and Media Studies (Online)",
    "deptCode": "FLMST",
    "collegeCode": "L&S",
    "relatedDeptCode": null,
    "inactive": false
  }
]
```
 