### PR TITLE
AL - Remove unneeded package-lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
This small PR removes a `package-lock.json` file in the root directory of the repository that should not be there. The only `package-lock.json` that should exist is the one in the javascript directory.

This was initially introduced in #75.