### PR TITLE
ds/mr - updated title for main index page 

### DIFF
--- a/javascript/public/index.html
+++ b/javascript/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Demo CRA + Spring App</title>
+    <title>UCSB Courses Search</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This pull request closes issue #124 by replacing the text on the tab that says "Demo CRA + Spring App" to "UCSB Courses Search".

This image displays the change:
<img width="308" alt="Screen Shot 2021-02-23 at 4 54 33 PM" src="https://user-images.githubusercontent.com/48531579/108930351-a4144e00-75fa-11eb-9476-0cf12f8efdaa.png">
