### PR TITLE
5pm-1 convert admin navbar button into dropdown, add empty admin settings page

### DIFF
--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -11,7 +11,7 @@ import About from "main/pages/About/About";
 import Statistics from "main/pages/Statistics/Statistics";
 import NumFullCoursesByDept from "main/pages/Statistics/NumFullCoursesByDept";
 import NumOpenCoursesByDept from "main/pages/Statistics/NumOpenCoursesByDept";
-import DivisionOccupancy from "main/pages/Statistics/DivisionOccupancy"
+import DivisionOccupancy from "main/pages/Statistics/DivisionOccupancy";
 import ClassSize from "main/pages/Statistics/ClassSize";
 import TotalCourses from "main/pages/Statistics/TotalCourses";
 import Schedule from "main/pages/Schedule/Schedule";
@@ -25,16 +25,14 @@ import Instructor from "main/pages/History/Instructor";
 import Profile from "main/pages/Profile/Profile";
 import PrivateRoute from "main/components/Auth/PrivateRoute";
 import Admin from "main/pages/Admin/Admin";
+import AdminSettings from "main/pages/Admin/AdminSettings";
 import useSWR from "swr";
 import { fetchWithToken } from "main/utils/fetch";
 import CourseName from "./pages/History/CourseName";
 
 function App() {
   const { isLoading, getAccessTokenSilently: getToken } = useAuth0();
-  const { data: roleInfo } = useSWR(
-    ["/api/myRole", getToken],
-    fetchWithToken
-  );
+  const { data: roleInfo } = useSWR(["/api/myRole", getToken], fetchWithToken);
   const _isAdmin = roleInfo && roleInfo.role.toLowerCase() === "admin";
 
   if (isLoading) {
@@ -50,20 +48,64 @@ function App() {
           <Route path="/history/basic" exact component={Basic} />
           <Route path="/history/courseName" exact component={CourseName} />
           <Route path="/statistics" exact component={Statistics} />
-          <Route path="/statistics/numFullCoursesByDept" exact component={NumFullCoursesByDept} />
-          <Route path="/statistics/numOpenCoursesByDept" exact component={NumOpenCoursesByDept} />
+          <Route
+            path="/statistics/numFullCoursesByDept"
+            exact
+            component={NumFullCoursesByDept}
+          />
+          <Route
+            path="/statistics/numOpenCoursesByDept"
+            exact
+            component={NumOpenCoursesByDept}
+          />
           <Route path="/statistics/classSize" exact component={ClassSize} />
-          <Route path="/statistics/totalCourses" exact component={TotalCourses} />
-          <Route path="/statistics/courseOccupancy" exact component={CourseOccupancy} />
+          <Route
+            path="/statistics/totalCourses"
+            exact
+            component={TotalCourses}
+          />
+          <Route
+            path="/statistics/courseOccupancy"
+            exact
+            component={CourseOccupancy}
+          />
           <Route path="/history/ge" exact component={Ge} />
           <Route path="/history/instructor" exact component={Instructor} />
-          <Route path="/statistics/courseOccupancyByDivision" exact component={DivisionOccupancy} />
+          <Route
+            path="/statistics/courseOccupancyByDivision"
+            exact
+            component={DivisionOccupancy}
+          />
           <PrivateRoute path="/profile" component={Profile} />
-          <AuthorizedRoute path="/admin" component={Admin} authorizedRoles={["admin"]}  />
+          <AuthorizedRoute
+            path="/admin/panel"
+            component={Admin}
+            authorizedRoles={["admin"]}
+          />
+          <AuthorizedRoute
+            path="/admin/settings"
+            component={AdminSettings}
+            authorizedRoles={["admin"]}
+          />
           <Route path="/about" component={About} />
-          <AuthorizedRoute path="/schedule" component={Schedule} exact authorizedRoles={["admin", "member"]}/>
-          <AuthorizedRoute path="/schedule/new" component={NewSchedule} exact authorizedRoles={["admin", "member"]}/>
-          <AuthorizedRoute path="/schedule/update/:scheduleId" component={EditSchedule} exact authorizedRoles={["admin", "member"]}/>
+          <AuthorizedRoute
+            path="/schedule"
+            component={Schedule}
+            exact
+            authorizedRoles={["admin", "member"]}
+          />
+          <AuthorizedRoute
+            path="/schedule/new"
+            component={NewSchedule}
+            exact
+            authorizedRoles={["admin", "member"]}
+          />
+          <AuthorizedRoute
+            path="/schedule/update/:scheduleId"
+            component={EditSchedule}
+            exact
+            authorizedRoles={["admin", "member"]}
+          />
         </Switch>
       </Container>
       <AppFooter />

--- a/javascript/src/main/components/Nav/AppNavbar.js
+++ b/javascript/src/main/components/Nav/AppNavbar.js
@@ -8,67 +8,73 @@ import useSWR from "swr";
 import { useAuth0 } from "@auth0/auth0-react";
 import { fetchWithToken } from "main/utils/fetch";
 
-
 function AppNavbar() {
   const { getAccessTokenSilently: getToken } = useAuth0();
-  const { data: roleInfo } = useSWR(
-    ["/api/myRole", getToken],
-    fetchWithToken
-  );
+  const { data: roleInfo } = useSWR(["/api/myRole", getToken], fetchWithToken);
   const isAdmin = roleInfo && roleInfo.role.toLowerCase() === "admin";
   const isMember = roleInfo && roleInfo.role.toLowerCase() === "member";
-  
+
   return (
     <Navbar expand="lg" bg="dark" variant="dark">
       <Navbar.Toggle />
       <Navbar.Collapse>
-      <LinkContainer to={""}>
-        <Navbar.Brand data-testid="brand">UCSB Courses Search</Navbar.Brand>
-      </LinkContainer>
-      <Nav>
-        <NavDropdown title="Course History">
-            <NavDropdown.Item href="/history/basic">Basic Search</NavDropdown.Item>
-            <NavDropdown.Item href="/history/courseName">Search By Course Name</NavDropdown.Item>
-            <NavDropdown.Item href="/history/ge">GE Search</NavDropdown.Item>
-            <NavDropdown.Item href="/history/instructor">Search By Instructor</NavDropdown.Item>
-        </NavDropdown>
-        { isAdmin &&
-          (<LinkContainer to={"/admin"}>
-            <Nav.Link>Admin</Nav.Link>
-          </LinkContainer>)
-        }
-        <LinkContainer to={"/about"}>
-            <Nav.Link>About</Nav.Link>
+        <LinkContainer to={""}>
+          <Navbar.Brand data-testid="brand">UCSB Courses Search</Navbar.Brand>
         </LinkContainer>
-        <NavDropdown title="Statistics">
-          <NavDropdown.Item as={Link} to="/statistics/numFullCoursesByDept">
-            Full Classes by Department
-          </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/statistics/courseOccupancy">
-            Course Occupancy by Department
-          </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/statistics/courseOccupancyByDivision">
-            Course Occupancy by Class Division
-          </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/statistics/classSize">
-            Average Class Size by Department
-          </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/statistics/totalCourses">
-            Total Courses by Department
-          </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/statistics/numOpenCoursesByDept">
-            Open Courses by Department
-          </NavDropdown.Item>
-        </NavDropdown>
-        { (isAdmin || isMember) &&
-            (<ScheduleNav/>)
-        }
-
-        
-      </Nav>
-      <Navbar.Collapse className="justify-content-end">
-        <AuthNav />
-      </Navbar.Collapse>
+        <Nav>
+          <NavDropdown title="Course History">
+            <NavDropdown.Item href="/history/basic">
+              Basic Search
+            </NavDropdown.Item>
+            <NavDropdown.Item href="/history/courseName">
+              Search By Course Name
+            </NavDropdown.Item>
+            <NavDropdown.Item href="/history/ge">GE Search</NavDropdown.Item>
+            <NavDropdown.Item href="/history/instructor">
+              Search By Instructor
+            </NavDropdown.Item>
+          </NavDropdown>
+          {isAdmin && (
+            <NavDropdown title="Admin">
+              <NavDropdown.Item as={Link} to={"/admin/panel"}>
+                Admin Panel
+              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to={"/admin/settings"}>
+                Admin Settings
+              </NavDropdown.Item>
+            </NavDropdown>
+          )}
+          <LinkContainer to={"/about"}>
+            <Nav.Link>About</Nav.Link>
+          </LinkContainer>
+          <NavDropdown title="Statistics">
+            <NavDropdown.Item as={Link} to="/statistics/numFullCoursesByDept">
+              Full Classes by Department
+            </NavDropdown.Item>
+            <NavDropdown.Item as={Link} to="/statistics/courseOccupancy">
+              Course Occupancy by Department
+            </NavDropdown.Item>
+            <NavDropdown.Item
+              as={Link}
+              to="/statistics/courseOccupancyByDivision"
+            >
+              Course Occupancy by Class Division
+            </NavDropdown.Item>
+            <NavDropdown.Item as={Link} to="/statistics/classSize">
+              Average Class Size by Department
+            </NavDropdown.Item>
+            <NavDropdown.Item as={Link} to="/statistics/totalCourses">
+              Total Courses by Department
+            </NavDropdown.Item>
+            <NavDropdown.Item as={Link} to="/statistics/numOpenCoursesByDept">
+              Open Courses by Department
+            </NavDropdown.Item>
+          </NavDropdown>
+          {(isAdmin || isMember) && <ScheduleNav />}
+        </Nav>
+        <Navbar.Collapse className="justify-content-end">
+          <AuthNav />
+        </Navbar.Collapse>
       </Navbar.Collapse>
     </Navbar>
   );

--- a/javascript/src/main/pages/Admin/AdminSettings.jsx
+++ b/javascript/src/main/pages/Admin/AdminSettings.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const AdminSettings = () => {
+  return <div>Admin Settings</div>;
+};
+
+export default AdminSettings;

--- a/javascript/src/test/pages/Admin/Settings.test.js
+++ b/javascript/src/test/pages/Admin/Settings.test.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import AdminSettings from "main/pages/Admin/AdminSettings";
+
+describe("Admin Settings tests", () => {
+  test("renders without crashing", () => {
+    const { getByText } = render(<AdminSettings />);
+    expect(getByText("Admin Settings")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR includes changes that convert the `Admin` button in the navbar into a dropdown button with the options: admin panel and admin settings. The paths for the 2 options are `/admin/panel` and `/admin/settings` respectively. An empty settings page was created which is rendered at the `/admin/settings` route.

closes #187 