### PR TITLE
5pm-2 Added spacing to end footer

### DIFF
--- a/javascript/src/main/App.css
+++ b/javascript/src/main/App.css
@@ -1,5 +1,6 @@
 .App {
   text-align: center;
+  padding-bottom:100px;
 }
 
 .App-logo {


### PR DESCRIPTION
This PR closes issue #200 .
100 pixels of space is added right before the footer so the footer does not cover the tables.

The image below demonstrates these changes (gif with a slow start).
![SRTeeDHZPb](https://user-images.githubusercontent.com/59630890/110404639-0ece7c00-8034-11eb-9ec3-02fc844ea635.gif)
