### PR TITLE
5pm 1 Fix bug of checking on full in BasicCourseTableHelpers

### DIFF
--- a/javascript/src/main/fixtures/Courses/BasicCourseTableHelpersFixtures.js
+++ b/javascript/src/main/fixtures/Courses/BasicCourseTableHelpersFixtures.js
@@ -593,7 +593,7 @@ export const classesInputSectionCancelledClosedFull = [
                 "section": "0103",
                 "classClosed": null,
                 "courseCancelled": null,
-                "enrolledTotal": 26,
+                "enrolledTotal": 25,
                 "maxEnroll": 25,
                 "timeLocations": [
                     {
@@ -612,7 +612,7 @@ export const classesInputSectionCancelledClosedFull = [
                 "section": "0104",
                 "classClosed": null,
                 "courseCancelled": null,
-                "enrolledTotal": 25,
+                "enrolledTotal": 24,
                 "maxEnroll": 25,
                 "timeLocations": [
                     {
@@ -646,7 +646,8 @@ export const classesInputSectionCancelledClosedFull = [
                 "instructors": []
             }
         ]
-    }];
+    }
+];
 
 export const sectionsOutput = [
     {
@@ -964,7 +965,7 @@ export const sectionsOutputCancelledClosedFull = [
                 "classClosed": null,
                 "courseCancelled": null,
                 "enrollCode": "07526",
-                "enrolledTotal": 26,
+                "enrolledTotal": 25,
                 "instructors": [],
                 "maxEnroll": 25,
                 "section": "0103",
@@ -989,7 +990,7 @@ export const sectionsOutputCancelledClosedFull = [
                 },
                 "courseCancelled": null,
                 "enrollCode": "07534",
-                "enrolledTotal": 25,
+                "enrolledTotal": 24,
                 "instructors": [],
                 "maxEnroll": 25,
                 "section": "0104",
@@ -1054,7 +1055,7 @@ export const sectionsOutputCancelledClosedFull = [
         "section": '0104',
         "classClosed": null,
         "courseCancelled": null,
-        "enrolledTotal": 25,
+        "enrolledTotal": 24,
         "maxEnroll": 25,
         "timeLocations": [{
             "room": "LINE",

--- a/javascript/src/main/utils/BasicCourseTableHelpers.js
+++ b/javascript/src/main/utils/BasicCourseTableHelpers.js
@@ -1,7 +1,7 @@
 const shouldShowSection = (section, filters) => {
   return ((!filters.cancelled) || (filters.cancelled && section.courseCancelled === null)) &&
     ((!filters.closed) || (filters.closed && section.classClosed === null)) &&
-    ((!filters.full) || (filters.full && section.maxEnroll >= section.enrolledTotal))
+    ((!filters.full) || (filters.full && section.maxEnroll > section.enrolledTotal))
 };
 
 

--- a/javascript/src/test/utils/BasicCourseTableHelpers.test.js
+++ b/javascript/src/test/utils/BasicCourseTableHelpers.test.js
@@ -8,7 +8,7 @@ describe("BasicCourseTableHelpers tests", () => {
     const testOutput = reformatJSON(helperFixtures.classesInput,checks);
     expect(testOutput).toStrictEqual(helperFixtures.sectionsOutput);
   });
-
+ 
   const checks2 = [false,true,false];
   test("reformatJSON properly reformats the json while closed set to true and the lecture should be hided", () => {
     const testOutput = reformatJSON(helperFixtures.classesInputLectureClosed,checks2);


### PR DESCRIPTION
We fixed a small bug in a merged pull request #198. In BasicCourseFilterHelper, while checking for if a course is full, we should identify the section as available if section.maxEnroll > section.enrolledTotal, but we add one more "=" equal sign. Now we removed that.