### PR TITLE
pc - add swagger-ui endpoint and /api/docs endpoints for RESTful API doc and testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,31 +91,31 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 
-		 <!-- https://mvnrepository.com/artifact/javax.persistence/javax.persistence-api -->
-		 <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <version>2.2</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.springframework.data/spring-data-jpa -->
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-jpa</artifactId>
-            <version>2.3.5.RELEASE</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>2.3.5.RELEASE</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+		<!-- https://mvnrepository.com/artifact/javax.persistence/javax.persistence-api -->
+		<dependency>
+			<groupId>javax.persistence</groupId>
+			<artifactId>javax.persistence-api</artifactId>
+			<version>2.2</version>
 		</dependency>
-		
+
+		<!-- https://mvnrepository.com/artifact/org.springframework.data/spring-data-jpa -->
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+			<version>2.3.5.RELEASE</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<version>2.3.5.RELEASE</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
+
 		<!-- https://mvnrepository.com/artifact/net.codebox/javabean-tester -->
 		<dependency>
 			<groupId>net.codebox</groupId>
@@ -123,11 +123,24 @@
 			<version>1.0.0</version>
 		</dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-            <version>1.8</version>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.8</version>
+		</dependency>
+
+		<!-- https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api -->
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/edu/ucsb/courses/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/courses/config/SecurityConfig.java
@@ -16,8 +16,13 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
 
   @Override
   public void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests().mvcMatchers("/api/public/**").permitAll().mvcMatchers("/api/**")
-        .authenticated().anyRequest().permitAll();
+    http.authorizeRequests()
+    .mvcMatchers("/**").permitAll()
+    .mvcMatchers("/api/public/**").permitAll()
+    .mvcMatchers("/swagger-ui/**").permitAll()
+    .mvcMatchers("/api/docs").permitAll()
+    .mvcMatchers("/api/**")
+    .authenticated().anyRequest().permitAll();
   }
 
   @Override

--- a/src/main/java/edu/ucsb/courses/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/courses/config/SpringFoxConfig.java
@@ -1,0 +1,30 @@
+package edu.ucsb.courses.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+
+/**
+ * Configuration for Swagger, a package that provides documentation
+ * for REST API endpoints.
+ * @see <a href="https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
+ */
+
+@Configuration
+public class SpringFoxConfig {                                    
+    @Bean
+    public Docket api() { 
+        return new Docket(DocumentationType.SWAGGER_2)
+          .select()              
+          .apis(RequestHandlerSelectors.any())    
+          .paths(regex("/api/.*"))                      
+          .build();                                           
+    }
+}

--- a/src/main/java/edu/ucsb/courses/controllers/ReactController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/ReactController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class ReactController {
-   @RequestMapping(value = {"/", "/{x:^(?!(api|swagger-ui)$)[\\w\\-]+}", "/{x:^(?!(api|swagger-ui)$).*$}/**/{y:[\\w\\-]+}"})
+   @RequestMapping(value = {"/", "/{x:^(?!swagger-ui$)[\\w\\-]+}", "/{x:^(?!api$).*$}/**/{y:[\\w\\-]+}"})
    public String getIndex() {
      return "/index.html";
    }

--- a/src/main/java/edu/ucsb/courses/controllers/ReactController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/ReactController.java
@@ -5,8 +5,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class ReactController {
-  @RequestMapping(value = {"/", "/{x:[\\w\\-]+}", "/{x:^(?!api$).*$}/**/{y:[\\w\\-]+}"})
-  public String getIndex() {
-    return "/index.html";
-  }
+   @RequestMapping(value = {"/", "/{x:^(?!(api|swagger-ui)$)[\\w\\-]+}", "/{x:^(?!(api|swagger-ui)$).*$}/**/{y:[\\w\\-]+}"})
+   public String getIndex() {
+     return "/index.html";
+   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+management.endpoints.web.exposure.include=mappings
+springfox.documentation.swagger.v2.path=/api/docs
 app.member.hosted-domain=ucsb.edu
 spring.config.location=classpath:/
 @environment-properties@


### PR DESCRIPTION
In this PR, we add two dependencies that adds an endpoint /swagger-ui/ with a UI for documenting and testing the RESTful API endpoints plus a JSON endpoint /api/docs, both available without authentication.

Try it here: <https://proj-ucsb-courses-search-qa.herokuapp.com/swagger-ui/>

Here's what the endpoint looks like:

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/1119017/113952769-3481a900-97cb-11eb-92ed-2a934e816eaf.png">

Each of the blue boxes can be clicked on and opened up up to reveal controls where you can submit a request:

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/1119017/113952849-5d09a300-97cb-11eb-9d5e-1e7926f7b259.png">


Note that authenticated endpoints still require a JWT.   One can be obtained if
and only if you are already logged in, by copying/pasting from the developer tools
and pasting into the Authentication field.

In future work, we can add annotations to our endpoints to add additional documentation to each of the endpoints, and each of the required fields in the endpoint.